### PR TITLE
Initialize e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ helios-ts/node_modules
 helios-ts/dist
 helios-ts/helios-*.tgz
 helios-ts/pkg
+helios-e2e-temp-config.toml
 
 .vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ dependencies = [
  "derive_more",
  "foldhash",
  "hashbrown 0.15.2",
- "indexmap",
+ "indexmap 2.7.1",
  "itoa",
  "k256",
  "keccak-asm",
@@ -599,7 +599,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.7.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -1137,6 +1137,34 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
@@ -1161,7 +1189,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
@@ -1195,12 +1223,29 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1218,7 +1263,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1238,7 +1283,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2251,6 +2296,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
+name = "duct"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,6 +2616,12 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2979,7 +3042,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2998,7 +3061,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -3014,6 +3077,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -3066,7 +3135,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helios"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "alloy",
  "criterion",
@@ -3094,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "helios-cli"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "alloy",
  "clap",
@@ -3116,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "helios-common"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "alloy",
  "eyre",
@@ -3128,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "helios-consensus-core"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -3155,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "helios-core"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "alloy",
  "alloy-trie",
@@ -3183,8 +3252,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "helios-e2e-tests"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "duct",
+ "eyre",
+ "figment",
+ "futures",
+ "kurtosis-sdk",
+ "pretty_assertions",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "toml 0.8.20",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "helios-ethereum"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "alloy",
  "alloy-trie",
@@ -3220,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "helios-linea"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "alloy",
  "eyre",
@@ -3238,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "helios-opstack"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -3430,6 +3523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3584,6 +3686,18 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.32",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -3872,6 +3986,16 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "indexmap"
@@ -4185,6 +4309,19 @@ checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
+]
+
+[[package]]
+name = "kurtosis-sdk"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb0ce1edbb21a23ca43225602480bbae3b48c61b86524515ac65399fa80e0a87"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -4794,6 +4931,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "multistream-select"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5205,6 +5348,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_pipe"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5373,6 +5526,16 @@ dependencies = [
  "memchr",
  "thiserror 2.0.11",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
@@ -5556,6 +5719,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5694,6 +5867,60 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -5948,7 +6175,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -6518,7 +6745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
 dependencies = [
  "form_urlencoded",
- "indexmap",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -6530,7 +6757,7 @@ version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -6602,7 +6829,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -6684,6 +6911,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_child"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e297bd52991bbe0686c086957bee142f13df85d1e79b0b21630a99d374ae9dc"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6947,6 +7184,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -7171,6 +7414,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7290,11 +7543,52 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum 0.6.20",
+ "base64 0.21.7",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7305,8 +7599,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7321,7 +7620,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -7920,6 +8219,18 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
 
 [[package]]
 name = "widestring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "verifiable-api/client",
     "verifiable-api/server",
     "verifiable-api/types", "linea",
+    "e2e-tests",
 ]
 
 default-members = ["cli"]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -153,14 +153,20 @@ struct EthereumArgs {
     load_external_fallback: bool,
     #[arg(short = 's', long, env)]
     strict_checkpoint_age: bool,
+    #[arg(long, help = "Path to the Helios custom configuration file")]
+    config_path: Option<PathBuf>,
 }
 
 impl EthereumArgs {
     fn make_client(&self) -> EthereumClient<FileDB> {
-        let config_path = home_dir().unwrap().join(".helios/helios.toml");
+        let config_path = match &self.config_path {
+            Some(path) => path.clone(),
+            None => home_dir().unwrap().join(".helios/helios.toml"),
+        };
         let cli_config = self.as_cli_config();
         let config = EthereumConfig::from_file(&config_path, &self.network, &cli_config);
 
+        println!("Config: {:?}", config);
         match EthereumClientBuilder::new()
             .config(config)
             .build::<FileDB>()

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "helios-e2e-tests"
+version = "0.1.0" # Use a specific version, not workspace for now, might change later
+edition = "2021"
+publish = false # This crate is not meant to be published
+
+[dependencies]
+alloy.workspace = true
+tokio = { version = "1", features = ["full"] }
+eyre = "0.6"
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+reqwest = { version = "0.12", features = ["json"] }
+url = "2.5"
+futures = "0.3"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+rand = "0.8"
+tempfile = "3.4"
+duct = "0.13.7"
+kurtosis-sdk = "1.7.2"
+toml = "0.8"
+figment = { version = "0.10", features = ["toml"] }
+
+[dev-dependencies]
+pretty_assertions = "1.4" 

--- a/e2e-tests/src/ethereum.rs
+++ b/e2e-tests/src/ethereum.rs
@@ -1,0 +1,58 @@
+// src/ethereum.rs
+
+use crate::harness::TestHarness;
+use alloy::primitives::U64;
+use alloy::providers::{Provider, ProviderBuilder};
+use anyhow::Result;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::json;
+use url::Url;
+
+// Helper struct for deserializing the JSON-RPC response for eth_chainId
+#[derive(Deserialize, Debug)]
+struct JsonRpcResponse {
+    result: String, // Chain ID as hex string e.g., "0x1"
+}
+
+// Basic test to check if Helios starts and RPC is reachable,
+// and if it reports the same chain ID as the EL client.
+#[tokio::test]
+// No longer ignored: #[ignore] // Ignored until harness setup is implemented
+async fn test_chain_id() -> Result<()> {
+    // Initialize logging (optional, good for debugging)
+    // let _ = tracing_subscriber::fmt::try_init();
+
+    // 1. Setup the harness for Ethereum
+    let harness = TestHarness::setup(/* Some config */).await?;
+    println!("Harness setup complete");
+
+    // 2. Get chain ID from the Execution Layer (EL) client directly
+    let el_rpc_url = Url::parse(&harness.el_url)?;
+    let el_provider = ProviderBuilder::new().on_http(el_rpc_url);
+    let el_chain_id_u64 = el_provider.get_chain_id().await?;
+    let el_chain_id: u64 = el_chain_id_u64.into(); // Convert U64 to u64
+
+    // 3. Get chain ID from Helios
+    let helios_rpc_url_str = harness.helios_rpc_url();
+    let helios_rpc_url = Url::parse(helios_rpc_url_str)?;
+    let helios_provider = ProviderBuilder::new().on_http(helios_rpc_url);
+    let helios_chain_id_u64 = helios_provider.get_chain_id().await?;
+    let helios_chain_id: u64 = helios_chain_id_u64.into(); // Convert U64 to u64
+
+    // 4. Assert the results
+    assert_eq!(
+        el_chain_id, helios_chain_id,
+        "Chain ID mismatch: EL client returned {}, Helios returned {}",
+        el_chain_id, helios_chain_id
+    );
+
+    println!(
+        "Successfully fetched chain ID from EL client ({}) and Helios ({}). They match!",
+        el_chain_id, helios_chain_id
+    );
+
+    Ok(())
+}
+
+// Add more Ethereum-specific E2E tests here...

--- a/e2e-tests/src/harness/mod.rs
+++ b/e2e-tests/src/harness/mod.rs
@@ -1,0 +1,380 @@
+// src/harness/mod.rs
+
+// This module will contain the logic for setting up and tearing down
+// the test environment (Kurtosis, Helios instance, etc.).
+
+use kurtosis_sdk::{
+    enclave_api::{api_container_service_client::ApiContainerServiceClient, GetServicesArgs},
+    engine_api::engine_service_client::EngineServiceClient,
+};
+
+use anyhow::Result;
+use duct::{cmd, Handle, ReaderHandle};
+use figment::value::{Dict, Value};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+use toml;
+
+/// Represents the running test environment.
+pub struct TestHarness {
+    pub cl_url: String,
+    pub el_url: String,
+    pub helios_url: String,
+    helios_handle: Option<ReaderHandle>,
+    path_to_config: PathBuf,
+}
+
+impl TestHarness {
+    /// Sets up the test environment for a specific network.
+    pub async fn setup(/* config: NetworkConfig */) -> Result<Self> {
+        // 1. Start Kurtosis environment and run an ethereum-package enclave
+        let args = vec![
+            "run",
+            "--enclave",
+            "helios-testnet",
+            "github.com/ethpandaops/ethereum-package",
+        ];
+        let kurtosis_engine_start = cmd("kurtosis", args)
+            .stdout_capture() // Suppress stdout
+            .stderr_to_stdout()
+            .run()?;
+        println!("Kurtosis engine started");
+        let (cl_url, el_url) = get_node_urls().await?;
+        // 5. Prepare Helios config (temp data dir, pass network details) with data from step 4
+        // 6. Fetch checkpoint from `/eth/v1/beacon/blocks/finalized/root`
+        let path_to_config = generate_config_file(&cl_url, &el_url).await?;
+
+        // 7. Build Helios CLI
+        let build_helios = cmd(
+            "cargo",
+            vec![
+                "build",
+                // "--release", // TODO: uncomment when time comes
+                "--manifest-path",
+                "../Cargo.toml", // Path to workspace root Cargo.toml
+            ],
+        )
+        .run()?;
+        println!("Built Helios: {:?}", build_helios);
+
+        // Get the absolute path to the built binary
+        let helios_binary = std::env::current_dir()?
+            .parent() // go up to workspace root
+            .unwrap()
+            // .join("target/release/helios"); // path to release binary
+            .join("target/debug/helios"); // path to dev binary
+        let helios_args = vec![
+            "ethereum",
+            "--config-path",
+            path_to_config.to_str().unwrap(),
+        ];
+
+        // Give Kurtosis some time before starting Helios
+        // TODO remove
+        println!("Sleeping for 25 seconds to give testnet some time");
+        tokio::time::sleep(Duration::from_secs(25)).await;
+
+        // Start Helios process and capture output
+        let helios_reader_handle = cmd(helios_binary, helios_args)
+            .stderr_to_stdout() // Merge stderr into stdout
+            .reader()?; // Get a reader instead of capturing
+
+        // Wait for Helios to sync
+        wait_for_sync(&helios_reader_handle)?;
+
+        println!("Helios is now synced and ready");
+        Ok(Self {
+            cl_url,
+            el_url,
+            helios_handle: Some(helios_reader_handle),
+            helios_url: "http://127.0.0.1:8545".to_string(), // TODO: get from Helios output or hardcode to config
+            path_to_config,
+        })
+    }
+
+    /// Returns the RPC URL for the running Helios instance.
+    pub fn helios_rpc_url(&self) -> &str {
+        // Replace with actual URL
+        "http://127.0.0.1:8545"
+    }
+}
+
+impl Drop for TestHarness {
+    fn drop(&mut self) {
+        println!("Dropping test harness");
+        if self.path_to_config.exists() {
+            println!("Removing generated config file: {:?}", self.path_to_config);
+            if let Err(e) = fs::remove_file(&self.path_to_config) {
+                eprintln!("Failed to remove config file: {}", e);
+            }
+        }
+
+        let args = vec!["enclave", "stop", "helios-testnet"];
+        let kurtosis_engine_stop = cmd("kurtosis", args).run().unwrap();
+        println!("Kurtosis engine stop: {:?}", kurtosis_engine_stop);
+        let args = vec!["clean"];
+        let kurtosis_clean = cmd("kurtosis", args).run().unwrap();
+        println!("Kurtosis clean: {:?}", kurtosis_clean);
+        let args = vec!["engine", "stop"];
+        let kurtosis_engine_stop = cmd("kurtosis", args).run().unwrap();
+        println!("Kurtosis engine stop: {:?}", kurtosis_engine_stop);
+        self.helios_handle.take().unwrap().kill().unwrap();
+        println!("Helios killed");
+    }
+}
+
+/**
+ * Using Kurtosis SDK to connect to Kurtosis enclave and get CL and EL RPC URLs
+ * for the test harness.
+*/
+async fn get_node_urls() -> Result<(String, String)> {
+    let mut engine = EngineServiceClient::connect("https://[::1]:9710").await?;
+    let mut enclaves = engine.get_enclaves(()).await?;
+    // println!("Enclaves: {:?}", enclaves);
+    let enclave_response = enclaves.into_inner();
+    let enclave_info = enclave_response
+        .enclave_info
+        .values()
+        .find(|info| info.name == "helios-testnet") // TODO change hardcoded
+        .expect("Helios testnet enclave not found");
+
+    let enclave_port = enclave_info
+        .api_container_host_machine_info
+        .as_ref()
+        .expect("API container host machine info must be present")
+        .grpc_port_on_host_machine;
+
+    // println!("FOUND Enclave port: {:?}", enclave_port);
+    let mut enclave =
+        ApiContainerServiceClient::connect(format!("https://[::1]:{}", enclave_port)).await?;
+    let services = enclave
+        .get_services(GetServicesArgs {
+            service_identifiers: HashMap::new(),
+        })
+        .await?;
+    // println!("Services: {:?}", services);
+    let service_response = services.into_inner();
+    // get the port numbers for the first service whose name starts with "cl-"
+
+    let mut cl_rpc_url = String::new();
+    let mut el_rpc_url = String::new();
+
+    for (name, service_info) in service_response.service_info.iter() {
+        if name.starts_with("cl-") {
+            if let Some(port_info) = service_info.maybe_public_ports.get("http") {
+                cl_rpc_url = format!("http://127.0.0.1:{}", port_info.number);
+            }
+        } else if name.starts_with("el-") {
+            if let Some(port_info) = service_info.maybe_public_ports.get("rpc") {
+                el_rpc_url = format!("http://127.0.0.1:{}", port_info.number);
+            }
+        }
+    }
+
+    if cl_rpc_url.is_empty() || el_rpc_url.is_empty() {
+        anyhow::bail!("Could not find CL or EL RPC URLs from Kurtosis services");
+    }
+
+    println!("CL RPC URL: {}", cl_rpc_url);
+    println!("EL RPC URL: {}", el_rpc_url);
+    Ok((cl_rpc_url, el_rpc_url))
+}
+
+// Structs for deserializing API responses (needed again)
+#[derive(Deserialize, Debug)]
+struct ApiData<T> {
+    data: T,
+}
+
+#[derive(Deserialize, Debug)]
+struct ConfigSpecResponse {
+    #[serde(rename = "DEPOSIT_CHAIN_ID")]
+    deposit_chain_id: String,
+    #[serde(rename = "GENESIS_FORK_VERSION")]
+    genesis_fork_version: String,
+    #[serde(rename = "ALTAIR_FORK_VERSION")]
+    altair_fork_version: String,
+    #[serde(rename = "ALTAIR_FORK_EPOCH")]
+    altair_fork_epoch: String,
+    #[serde(rename = "BELLATRIX_FORK_VERSION")]
+    bellatrix_fork_version: String,
+    #[serde(rename = "BELLATRIX_FORK_EPOCH")]
+    bellatrix_fork_epoch: String,
+    #[serde(rename = "CAPELLA_FORK_VERSION")]
+    capella_fork_version: String,
+    #[serde(rename = "CAPELLA_FORK_EPOCH")]
+    capella_fork_epoch: String,
+    #[serde(rename = "DENEB_FORK_VERSION")]
+    deneb_fork_version: String,
+    #[serde(rename = "DENEB_FORK_EPOCH")]
+    deneb_fork_epoch: String,
+    // Add ELECTRA if needed
+}
+
+#[derive(Deserialize, Debug)]
+struct GenesisResponse {
+    genesis_time: String,
+    genesis_validators_root: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct BlockRootResponse {
+    root: String,
+}
+
+/**
+ * Collect relevant data about consensus layer of the network to let Helios
+ * bootstrap with trusted checkpoint, genesis time, and fork schedule.
+ * TODO: rework
+ */
+async fn generate_config_file(cl_url: &str, el_url: &str) -> Result<PathBuf> {
+    let client = reqwest::Client::new();
+
+    // 1. Fetch spec
+    let spec_url = format!("{}/eth/v1/config/spec", cl_url);
+    let spec_data: ApiData<ConfigSpecResponse> = client
+        .get(&spec_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    // 2. Fetch genesis
+    let genesis_url = format!("{}/eth/v1/beacon/genesis", cl_url);
+    let genesis_data: ApiData<GenesisResponse> = client
+        .get(&genesis_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    // 3. Fetch finalized block root to use as a checkpoint
+    let checkpoint_url = format!("{}/eth/v1/beacon/blocks/finalized/root", cl_url);
+    let checkpoint_data: ApiData<BlockRootResponse> = client
+        .get(&checkpoint_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    // Parse data
+    let genesis_time: u64 = genesis_data.data.genesis_time.parse()?;
+    let chain_id: u64 = spec_data.data.deposit_chain_id.parse()?;
+    let genesis_root = genesis_data.data.genesis_validators_root;
+    let checkpoint = checkpoint_data.data.root;
+
+    // Build config using figment::Dict
+    let mut chain_config = Dict::new();
+    chain_config.insert("genesis_time".into(), Value::from(genesis_time));
+    chain_config.insert("chain_id".into(), Value::from(chain_id));
+    chain_config.insert("genesis_root".into(), Value::from(genesis_root));
+
+    let mut forks_config = Dict::new();
+    let mut genesis_fork = Dict::new();
+    genesis_fork.insert("epoch".into(), Value::from(0u64));
+    genesis_fork.insert(
+        "fork_version".into(),
+        Value::from(spec_data.data.genesis_fork_version),
+    );
+    forks_config.insert("genesis".into(), Value::from(genesis_fork));
+
+    let mut altair_fork = Dict::new();
+    altair_fork.insert(
+        "epoch".into(),
+        Value::from(spec_data.data.altair_fork_epoch.parse::<u64>()?),
+    );
+    altair_fork.insert(
+        "fork_version".into(),
+        Value::from(spec_data.data.altair_fork_version),
+    );
+    forks_config.insert("altair".into(), Value::from(altair_fork));
+
+    let mut bellatrix_fork = Dict::new();
+    bellatrix_fork.insert(
+        "epoch".into(),
+        Value::from(spec_data.data.bellatrix_fork_epoch.parse::<u64>()?),
+    );
+    bellatrix_fork.insert(
+        "fork_version".into(),
+        Value::from(spec_data.data.bellatrix_fork_version),
+    );
+    forks_config.insert("bellatrix".into(), Value::from(bellatrix_fork));
+
+    let mut capella_fork = Dict::new();
+    capella_fork.insert(
+        "epoch".into(),
+        Value::from(spec_data.data.capella_fork_epoch.parse::<u64>()?),
+    );
+    capella_fork.insert(
+        "fork_version".into(),
+        Value::from(spec_data.data.capella_fork_version),
+    );
+    forks_config.insert("capella".into(), Value::from(capella_fork));
+
+    let mut deneb_fork = Dict::new();
+    deneb_fork.insert(
+        "epoch".into(),
+        Value::from(spec_data.data.deneb_fork_epoch.parse::<u64>()?),
+    );
+    deneb_fork.insert(
+        "fork_version".into(),
+        Value::from(spec_data.data.deneb_fork_version),
+    );
+    forks_config.insert("deneb".into(), Value::from(deneb_fork));
+    // Add electra if needed
+
+    let mut mainnet_config = Dict::new();
+    mainnet_config.insert("consensus_rpc".into(), Value::from(cl_url));
+    mainnet_config.insert("execution_rpc".into(), Value::from(el_url));
+    mainnet_config.insert("checkpoint".into(), Value::from(checkpoint));
+    mainnet_config.insert("chain".into(), Value::from(chain_config));
+    mainnet_config.insert("forks".into(), Value::from(forks_config));
+
+    let mut helios_config = Dict::new();
+    helios_config.insert("mainnet".into(), Value::from(mainnet_config));
+
+    // Serialize to TOML string using the `toml` crate (figment Dict implements Serialize)
+    let toml_string = toml::to_string_pretty(&helios_config)?;
+
+    // Define the file path (e.g., in the e2e-tests directory)
+    // Using relative path from workspace root
+    let config_path = PathBuf::from("helios-e2e-temp-config.toml");
+
+    // Write the TOML string to the file using std::fs::write
+    fs::write(&config_path, toml_string)?;
+    println!("Generated Helios config file at: {:?}", config_path);
+
+    Ok(config_path)
+}
+
+/// Waits for Helios to sync by monitoring its output.
+/// Returns an error if sync doesn't complete within the timeout period.
+fn wait_for_sync(reader_handle: &ReaderHandle) -> Result<()> {
+    const SYNC_TIMEOUT: Duration = Duration::from_secs(20); // Adjust timeout as needed
+    const SYNC_MESSAGE: &str = "consensus client in sync with checkpoint:";
+
+    let start_time = Instant::now();
+    let reader = BufReader::new(reader_handle);
+
+    for line in reader.lines() {
+        let line = line?;
+        println!("Helios message: {:#?}", line);
+
+        if line.contains(SYNC_MESSAGE) {
+            return Ok(());
+        }
+
+        if start_time.elapsed() > SYNC_TIMEOUT {
+            anyhow::bail!("Timeout waiting for Helios to sync");
+        }
+    }
+
+    anyhow::bail!("Reader closed before sync message was found")
+}

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -1,0 +1,4 @@
+// src/lib.rs
+pub mod harness;
+pub mod ethereum;
+// Add other network modules here later (e.g., opstack, linea) 

--- a/ethereum/consensus-core/src/consensus_core.rs
+++ b/ethereum/consensus-core/src/consensus_core.rs
@@ -294,6 +294,15 @@ pub fn verify_generic_update<S: ConsensusSpec>(
 
     if let Some(finalized_header) = &update.finalized_header {
         if let Some(finality_branch) = &update.finality_branch {
+            // Special case for genesis block
+            let is_genesis = finalized_header.beacon().slot == 0
+                || (finalized_header.beacon().parent_root == B256::ZERO
+                    && calc_sync_period::<S>(finalized_header.beacon().slot) == 0);
+
+            if is_genesis {
+                // Genesis blocks are implicitly finalized
+                return Ok(());
+            }
             if !is_valid_header::<S>(finalized_header, forks) {
                 return Err(ConsensusError::InvalidExecutionPayloadProof.into());
             }

--- a/ethereum/consensus-core/src/consensus_core.rs
+++ b/ethereum/consensus-core/src/consensus_core.rs
@@ -378,7 +378,7 @@ pub fn force_update<S: ConsensusSpec>(store: &mut LightClientStore<S>, current_s
     }
 }
 
-pub fn expected_current_slot(now: SystemTime, genesis_time: u64) -> u64 {
+pub fn expected_current_slot<S: ConsensusSpec>(now: SystemTime, genesis_time: u64) -> u64 {
     let now = now
         .duration_since(UNIX_EPOCH)
         .unwrap_or_else(|_| panic!("unreachable"))
@@ -386,7 +386,7 @@ pub fn expected_current_slot(now: SystemTime, genesis_time: u64) -> u64 {
 
     let since_genesis = now - genesis_time;
 
-    since_genesis / 12
+    since_genesis / S::seconds_per_slot()
 }
 
 pub fn calc_sync_period<S: ConsensusSpec>(slot: u64) -> u64 {

--- a/ethereum/consensus-core/src/consensus_spec.rs
+++ b/ethereum/consensus-core/src/consensus_spec.rs
@@ -23,6 +23,11 @@ pub trait ConsensusSpec: 'static + Default + Sync + Send + Clone + Debug + Parti
     type MaxWithdrawalRequests: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxDepositRequests: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
     type MaxConsolidationRequests: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
+    type SecondsPerSlot: Unsigned + Default + Debug + Sync + Send + Clone + PartialEq;
+
+    fn seconds_per_slot() -> u64 {
+        Self::SecondsPerSlot::to_u64()
+    }
 
     fn slots_per_epoch() -> u64 {
         Self::SlotsPerEpoch::to_u64()
@@ -64,6 +69,7 @@ impl ConsensusSpec for MainnetConsensusSpec {
     type MaxDepositRequests = typenum::U8192;
     type MaxWithdrawalRequests = typenum::U16;
     type MaxConsolidationRequests = typenum::U2;
+    type SecondsPerSlot = typenum::U12;
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
@@ -89,4 +95,5 @@ impl ConsensusSpec for MinimalConsensusSpec {
     type MaxDepositRequests = typenum::U4;
     type MaxWithdrawalRequests = typenum::U2;
     type MaxConsolidationRequests = typenum::U1;
+    type SecondsPerSlot = typenum::U6;
 }

--- a/ethereum/consensus-core/src/proof.rs
+++ b/ethereum/consensus-core/src/proof.rs
@@ -20,9 +20,17 @@ pub fn is_finality_proof_valid(
         (41, 6)
     };
 
+    // if genesis, use genesis block header
+    // TODO make not ugly or remove and work around
+    let leaf_object = if finality_header.slot == 0 {
+        BeaconBlockHeader::default()
+    } else {
+        finality_header.clone()
+    };
+
     is_proof_valid(
         attested_header.state_root,
-        finality_header,
+        &leaf_object,
         finality_branch,
         depth,
         index,

--- a/ethereum/src/consensus.rs
+++ b/ethereum/src/consensus.rs
@@ -140,7 +140,8 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
             _ = inner.send_blocks().await;
 
             let start = Instant::now() + inner.duration_until_next_update().to_std().unwrap();
-            let mut interval = interval_at(start, std::time::Duration::from_secs(12));
+            let mut interval =
+                interval_at(start, std::time::Duration::from_secs(S::seconds_per_slot()));
 
             loop {
                 tokio::select! {
@@ -188,7 +189,7 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>, DB: Database> ConsensusClient<S, R, D
     pub fn expected_current_slot(&self) -> u64 {
         let now = SystemTime::now();
 
-        expected_current_slot(now, self.genesis_time)
+        expected_current_slot::<S>(now, self.genesis_time)
     }
 }
 
@@ -582,11 +583,11 @@ impl<S: ConsensusSpec, R: ConsensusRpc<S>> Inner<S, R> {
     pub fn expected_current_slot(&self) -> u64 {
         let now = SystemTime::now();
 
-        expected_current_slot(now, self.config.chain.genesis_time)
+        expected_current_slot::<S>(now, self.config.chain.genesis_time)
     }
 
     fn slot_timestamp(&self, slot: u64) -> u64 {
-        slot * 12 + self.config.chain.genesis_time
+        slot * S::seconds_per_slot() + self.config.chain.genesis_time
     }
 
     // Determines blockhash_slot age and returns true if it is less than 14 days old


### PR DESCRIPTION
**Important**: This is a draft PR to show a somewhat working setup for e2e tests. I will rewrite it more or less entirely. It has only one actual test to check if setup process works.

Changes **in Helios itself** that were necessary:
1. Don't hardcode `seconds_per_slot` value (12) for ethereum
2. When finality update is not available, use optimistic update without panicking. Helios wouldn't sync otherwise for at least 2 epochs, i.e about 30 minutes
3. Trust genesis block when checking finality proof
4. Add `--config-path` CLI argument to pass a temporary config file with testnet's parameters

Also the setup is currently:
- only for Ethereum 
- only in CLI mode, no WASM
### Prerequisites
1. Have docker running
2. Installed [Kurtosis CLI](https://docs.kurtosis.com/install/).

### Running tests (only 1) to check if harness works
Use command
```bash
cargo test --package helios-e2e-tests ethereum::test_chain_id -- --nocapture
```
